### PR TITLE
Improve Shrink - Assembly, Prevent Infinite Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ A Solidity Library for managing dynamic array of primitive types.
 1. Initial Implementation (✅)
 2. TypeScript (✅)
 3. Improve `shrink`
-   - Confirm: modifying `length` of dynamic array on storage will/won't erase stale area?  (✅)
+   - Confirm: modifying `length` of dynamic array on storage will/won't erase stale area? (✅)
+      - `delete a;` will set all it's elements as well as `a.length` to 0, when `a` is a dynamic/static array on storage. (**Update**: No gas refund since [London hardfork](https://eips.ethereum.org/EIPS/eip-3298))
+      - `a.length = 0;` will only set the length of `a`. For static array, length is immutable. Further, since v0.8, `a.length` is read-only, thus you need to use `assembly` to resize the array.
    - Gas costly cheap?
 4. Use Assembly
-   - Bounding check is accomplished by accessing array element by default. It's safe without it. Use low-level Assembly to skip it.
+   - Bounding check is accomplished by accessing array element by default. It's safe without it. Use low-level Assembly to skip it. (✅)
 5. Support types narrower than 32 bytes
    - The architecture is not gas costly effetive for primitive types smaller than 16 bytes. Any idea? 🙄
 
@@ -79,7 +81,7 @@ contract AddressBook {
 
   function deleteBook() external {
     book.clear();
-    book.shrink();
+    book.shrink(0);
   }
 }
 
@@ -100,18 +102,42 @@ npx hardhat test
 ```
 
 ```
-  Contract: DynamicArray
     DynamicBytes32Array
       √ starts empty
       set
-        √ reverts when setting at invalid position (54ms)
-        √ overwrites an existing position (63ms)
+        √ reverts when setting at invalid position
+        √ overwrites an existing position (72ms)
+      get
+        √ reverts when getting at invalid position
+        √ gets an existing position
+      push
+        √ adds at end (41ms)
+        √ adds at end but doesn't occupy new storage when it's been occupied already (80ms)
+      pop
+        √ removes at end and doesn't delete storage
+        √ reverts when popping in empty
+      size
+        √ returns size
+        √ may be different with capacity
+      capacity
+        √ returns capacity
+        √ may be different with size
+      clear
+        √ sets the size to 0, and doesn't delete storage
+      shrink
+        √ deletes stale storage (97ms)
+        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (97ms)
+    DynamicUintArray
+      √ starts empty
+      set
+        √ reverts when setting at invalid position
+        √ overwrites an existing position (52ms)
       get
         √ reverts when getting at invalid position
         √ gets an existing position
       push
         √ adds at end (38ms)
-        √ adds at end but doesn't occupy new storage when it's been occupied already (53ms)
+        √ adds at end but doesn't occupy new storage when it's been occupied already (80ms)
       pop
         √ removes at end and doesn't delete storage
         √ reverts when popping in empty
@@ -124,42 +150,19 @@ npx hardhat test
       clear
         √ sets the size to 0, and doesn't delete storage
       shrink
-        √ deletes stale storage (61ms)
-    DynamicUintArray
-      √ starts empty
-      set
-        √ reverts when setting at invalid position
-        √ overwrites an existing position
-      get
-        √ reverts when getting at invalid position
-        √ gets an existing position
-      push
-        √ adds at end
-        √ adds at end but doesn't occupy new storage when it's been occupied already (43ms)
-      pop
-        √ removes at end and doesn't delete storage
-        √ reverts when popping in empty
-      size
-        √ returns size
-        √ may be different with capacity
-      capacity
-        √ returns capacity
-        √ may be different with size
-      clear
-        √ sets the size to 0, and doesn't delete storage
-      shrink
-        √ deletes stale storage (49ms)
+        √ deletes stale storage (98ms)
+        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (97ms)
     DynamicAddressArray
       √ starts empty
       set
         √ reverts when setting at invalid position
-        √ overwrites an existing position
+        √ overwrites an existing position (42ms)
       get
         √ reverts when getting at invalid position
         √ gets an existing position
       push
-        √ adds at end
-        √ adds at end but doesn't occupy new storage when it's been occupied already (44ms)
+        √ adds at end (39ms)
+        √ adds at end but doesn't occupy new storage when it's been occupied already (81ms)
       pop
         √ removes at end and doesn't delete storage
         √ reverts when popping in empty
@@ -172,8 +175,9 @@ npx hardhat test
       clear
         √ sets the size to 0, and doesn't delete storage
       shrink
-        √ deletes stale storage (50ms)
+        √ deletes stale storage (97ms)
+        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (96ms)
 
 
-  45 passing (2s)
+  48 passing (4s)
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Solidity Library for managing dynamic array of primitive types.
 3. Improve `shrink`
    - Confirm: modifying `length` of dynamic array on storage will/won't erase stale area? (✅)
       - `delete a;` will set all it's elements as well as `a.length` to 0, when `a` is a dynamic/static array on storage. (**Update**: No gas refund since [London hardfork](https://eips.ethereum.org/EIPS/eip-3298))
-      - `a.length = 0;` will only set the length of `a`. For static array, length is immutable. Further, since v0.8, `a.length` is read-only, thus you need to use `assembly` to resize the array.
+      - `a.length = 0;` will only set the length of `a`. For static array, length is immutable. Further, since v0.6, `a.length` is read-only, thus you need to use `assembly` to resize the array.
    - Gas costly cheap?
 4. Use Assembly
    - Bounding check is accomplished by accessing array element by default. It's safe without it. Use low-level Assembly to skip it. (✅)

--- a/contracts/DynamicArray.sol
+++ b/contracts/DynamicArray.sol
@@ -109,15 +109,48 @@ library DynamicArray {
   }
 
   /**
-   * @dev Deletes stale items.
+   * @dev Deletes stale items as many as sufficient gas is available.
    * This is the only time data is deleted on storage.
    */
-  function _shrink(Array storage array) private {
-    uint256 length = array._length; // gas saving
-    uint256 occupied = array._data.length - length;
-    if (occupied == 0) return;
-    for (uint256 i = 0; i < occupied; ++i) {
-      array._data.pop(); // array.pop() will delete the storage slot implicitly, thus it refunds gas to caller.
+  function _shrink(Array storage array, uint256 gasTolerance) private {
+    assembly {
+      let length_ := sload(array.slot)
+      let data_ := add(array.slot, 0x01)
+      let capacity_ := sload(data_)
+      let occupied_ := sub(capacity_, length_) // never underflow
+      if eq(occupied_, 0) {
+        return(0, 0)
+      }
+      if gt(
+        number(),
+        0xC5D488 /* @dev FIXME London Fork Block Number */
+      ) {
+        sstore(data_, length_)
+        /// @dev No gas refunds since London Fork, thus just returns
+        return(0, 0)
+      }
+      mstore(0, data_)
+      let offset_ := keccak256(0, 0x20) // never greater than 2**256 - 1
+      /// @notice calculating storage slot of array element can overflow, since storage has 2**256 slots.
+      /// i.e. let end := add(offset, capacity) // can be greater than 2**256 - 1 aka. overflow
+      /// Thus, it cannot use slot number as the loop iterator.
+      /// Due to the nature, seemgly inefficient loop here 🤔
+      let index_ := capacity_
+      let gasLimit_ := add(gasTolerance, 20050) /// @dev FIXME add more for gracefully end up process, ref: https://github.com/crytic/evm-opcodes
+      for {
+
+      } gt(index_, length_) {
+        index_ := sub(index_, 1)
+      } {
+        /// @dev check available remaining gas
+        if lt(gas(), gasLimit_) {
+          break
+        }
+        /// @notice Provability of overflow/underflow, but this is designed as storage is continuum.
+        let slot := add(offset_, sub(index_, 1))
+        sstore(slot, 0)
+      }
+      sstore(data_, index_)
     }
   }
 
@@ -219,10 +252,11 @@ library DynamicArray {
    * @dev Deletes stale items.
    * This is the only time data is deleted on storage.
    *
-   * @param array     The array struct
+   * @param array         The array struct
+   * @param gasTolerance  The minimal gas amount should remain to prevent infinite loop
    */
-  function shrink(Bytes32Array storage array) internal {
-    _shrink(array._inner);
+  function shrink(Bytes32Array storage array, uint256 gasTolerance) internal {
+    _shrink(array._inner, gasTolerance);
   }
 
   // UintArray
@@ -323,10 +357,11 @@ library DynamicArray {
    * @dev Deletes stale items.
    * This is the only time data is deleted on storage.
    *
-   * @param array     The array struct
+   * @param array         The array struct
+   * @param gasTolerance  The minimal gas amount should remain to prevent infinite loop
    */
-  function shrink(UintArray storage array) internal {
-    _shrink(array._inner);
+  function shrink(UintArray storage array, uint256 gasTolerance) internal {
+    _shrink(array._inner, gasTolerance);
   }
 
   // AddressArray
@@ -427,9 +462,10 @@ library DynamicArray {
    * @dev Deletes stale items.
    * This is the only time data is deleted on storage.
    *
-   * @param array     The array struct
+   * @param array         The array struct
+   * @param gasTolerance  The minimal gas amount should remain to prevent infinite loop
    */
-  function shrink(AddressArray storage array) internal {
-    _shrink(array._inner);
+  function shrink(AddressArray storage array, uint256 gasTolerance) internal {
+    _shrink(array._inner, gasTolerance);
   }
 }

--- a/contracts/DynamicArray.sol
+++ b/contracts/DynamicArray.sol
@@ -150,7 +150,7 @@ library DynamicArray {
         let slot := add(offset_, sub(index_, 1))
         sstore(slot, 0)
       }
-      sstore(data_, index_)
+      sstore(data_, index_) // update capacity
     }
   }
 

--- a/contracts/example/AddressBook.sol
+++ b/contracts/example/AddressBook.sol
@@ -39,6 +39,6 @@ contract AddressBook {
 
   function deleteBook() external {
     book.clear();
-    book.shrink();
+    book.shrink(0);
   }
 }

--- a/contracts/mock/DynamicArrayMock.sol
+++ b/contracts/mock/DynamicArrayMock.sol
@@ -38,8 +38,8 @@ contract DynamicBytes32ArrayMock {
     _array.clear();
   }
 
-  function shrink() public {
-    _array.shrink();
+  function shrink(uint256 gasTolerance) public {
+    _array.shrink(gasTolerance);
   }
 }
 
@@ -77,8 +77,8 @@ contract DynamicUintArrayMock {
     _array.clear();
   }
 
-  function shrink() public {
-    _array.shrink();
+  function shrink(uint256 gasTolerance) public {
+    _array.shrink(gasTolerance);
   }
 }
 
@@ -116,7 +116,7 @@ contract DynamicAddressArrayMock {
     _array.clear();
   }
 
-  function shrink() public {
-    _array.shrink();
+  function shrink(uint256 gasTolerance) public {
+    _array.shrink(gasTolerance);
   }
 }

--- a/test/DynamicArray.test.ts
+++ b/test/DynamicArray.test.ts
@@ -159,10 +159,24 @@ function shouldBehaveLikeDynamicArray(values: string[]) {
       await this.array.push(values[2]);
       await this.array.pop();
       await this.array.pop();
-      await this.array.shrink();
+      await this.array.shrink(0);
       await expectArrayMatch(this.array, {
         length: 1,
         capacity: 1,
+        items: [values[0]],
+      });
+    });
+
+    it("fails to delete stale storage when insufficient gas limit provided, but not reverts", async function () {
+      await this.array.push(values[0]);
+      await this.array.push(values[1]);
+      await this.array.push(values[2]);
+      await this.array.pop();
+      await this.array.pop();
+      await this.array.shrink(100000, { gasLimit: 100000 });
+      await expectArrayMatch(this.array, {
+        length: 1,
+        capacity: 3,
         items: [values[0]],
       });
     });


### PR DESCRIPTION
### Summary Of Changes

This PR improves `shrink` function:
- Use inline assembly
   * in order to resize storage dynamic array in low-level, because `a.length` is read-only since solc v0.6
   * minimal gas optimization
- Block infinite loop
   * add `gasTolerance` parameter, in order to gracefully end up shrink process when insufficient gas provided for large size

### Testing Notes
`npm run test`

```
> dynamic-array@1.0.0 test
> hardhat test

Compiling 3 files with 0.8.4
Compilation finished successfully


  DynamicArray
    DynamicBytes32Array
      √ starts empty
      set
        √ reverts when setting at invalid position
        √ overwrites an existing position (83ms)
      get
        √ reverts when getting at invalid position
        √ gets an existing position
      push
        √ adds at end (41ms)
        √ adds at end but doesn't occupy new storage when it's been occupied already (69ms)
      pop
        √ removes at end and doesn't delete storage
        √ reverts when popping in empty
      size
        √ returns size
        √ may be different with capacity
      capacity
        √ returns capacity
        √ may be different with size
      clear
        √ sets the size to 0, and doesn't delete storage
      shrink
        √ deletes stale storage (98ms)
        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (81ms)
    DynamicUintArray
      √ starts empty
      set
        √ reverts when setting at invalid position
        √ overwrites an existing position
      get
        √ reverts when getting at invalid position
        √ gets an existing position
      push
        √ adds at end
        √ adds at end but doesn't occupy new storage when it's been occupied already (80ms)
      pop
        √ removes at end and doesn't delete storage
        √ reverts when popping in empty
      size
        √ returns size
        √ may be different with capacity
      capacity
        √ returns capacity
        √ may be different with size
      clear
        √ sets the size to 0, and doesn't delete storage
      shrink
        √ deletes stale storage (99ms)
        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (98ms)
    DynamicAddressArray
      √ starts empty
      set
        √ reverts when setting at invalid position
        √ overwrites an existing position
      get
        √ reverts when getting at invalid position
        √ gets an existing position
      push
        √ adds at end
        √ adds at end but doesn't occupy new storage when it's been occupied already (65ms)
      pop
        √ removes at end and doesn't delete storage
        √ reverts when popping in empty
      size
        √ returns size
        √ may be different with capacity
      capacity
        √ returns capacity
        √ may be different with size
      clear
        √ sets the size to 0, and doesn't delete storage
      shrink
        √ deletes stale storage (95ms)
        √ fails to delete stale storage when insufficient gas limit provided, but not reverts (95ms)


  48 passing (4s)
```

### Deployment Notes
- [ ] New Dependencies
- [x] API Changes

Closes #1 